### PR TITLE
ci: ci단계에서 반복적으로 일어나는 install 및 build에 cache를 적용하라

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,89 @@ on:
   push:
     branches: [main]
 
+env:
+  CACHED_DEPENDENCY_PATHS: |
+    ${{ github.workspace }}/.yarn/cache
+  CACHED_BUILD_PATHS: ${{ github.workspace }}/.next/cache
+  BUILD_CACHE_KEY: ${{ github.sha }}
+  DEFAULT_NODE_VERSION: '16'
+
 jobs:
-  continuous-integration:
+  job_install_dependencies:
+    name: Install Dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 16
+      - name: Check out current commit (${{ github.sha }})
+        uses: actions/checkout@v2
+      - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+
+      - name: Compute dependency cache key
+        id: compute_lockfile_hash
+        run: echo "::set-output name=hash::${{ hashFiles('yarn.lock') }}"
+
+      - name: Check dependency cache
+        uses: actions/cache@v3
+        id: cache_dependencies
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ steps.compute_lockfile_hash.outputs.hash }}
 
       - name: Install dependencies
+        if: steps.cache_dependencies.outputs.cache-hit == ''
         run: yarn install --immutable
+    outputs:
+      dependency_cache_key: ${{ steps.compute_lockfile_hash.outputs.hash }}
+
+  job_build:
+    name: Build
+    needs: [job_install_dependencies]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out current commit (${{ github.sha }})
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+
+      - name: Check dependency cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ needs.job_install_dependencies.outputs.dependency_cache_key }}
+      - name: Check build cache
+        uses: actions/cache@v3
+        id: cache_built_packages
+        with:
+          path: ${{ env.CACHED_BUILD_PATHS }}
+          key: ${{ env.BUILD_CACHE_KEY }}
+
+      - name: Build
+        if: steps.cache_built_packages.outputs.cache-hit == ''
+        run: yarn build
+
+  job_continuous_integration:
+    runs-on: ubuntu-latest
+    name: check test & lint
+    needs: [job_install_dependencies]
+    steps:
+      - name: Check out current commit (${{ github.sha }})
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+
+      - name: Check dependency cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ needs.job_install_dependencies.outputs.dependency_cache_key }}
 
       - name: Check Lint
         if: github.event_name != 'push'
@@ -40,17 +111,23 @@ jobs:
           command-prefix: yarn dlx
           start: yarn dev
 
-  set-codecov-test-coverage:
+  job_codecov_test_coverage:
+    name: set codecov unit test coverage
     runs-on: ubuntu-latest
+    needs: [job_install_dependencies]
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 16
+      - name: Check out current commit (${{ github.sha }})
+        uses: actions/checkout@v2
+      - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
 
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Check dependency cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ needs.job_install_dependencies.outputs.dependency_cache_key }}
 
       - name: Create Unit Test Coverage
         run: yarn test:coverage
@@ -60,3 +137,34 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+
+  job_nextjs_bundle_analysis:
+    name: nextjs bundle analysis
+    runs-on: ubuntu-latest
+    needs: [job_build]
+    steps:
+      - name: Check out current commit (${{ github.sha }})
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+
+      - name: Check dependency cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ needs.job_build.outputs.dependency_cache_key }}
+      - name: Check build cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHED_BUILD_PATHS }}
+          key: ${{ env.BUILD_CACHE_KEY }}
+
+      - name: Analyze bundle sizes
+        uses: transferwise/actions-next-bundle-analyzer@master
+        with:
+          workflow-id: ci.yml
+          base-branch: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,16 +101,14 @@ jobs:
         if: github.event_name != 'push'
         run: yarn test:unit
 
-      - name: Install cypress dependencies
-        run: yarn add cypress
-
       - name: Run Cypress with Chrome
         uses: cypress-io/github-action@v3.1.0
         with:
           browser: chrome
           record: true
           config-file: cypress.config.js
-          install: false
+          install-command: yarn install --immutable
+          command-prefix: yarn dlx
           start: yarn dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,17 +101,20 @@ jobs:
         if: github.event_name != 'push'
         run: yarn test:unit
 
+      - name: Install cypress dependencies
+        run: yarn add cypress
+
       - name: Run Cypress with Chrome
         uses: cypress-io/github-action@v3.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         with:
           browser: chrome
           record: true
           config-file: cypress.config.js
           install: false
           start: yarn dev
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
   job_codecov_test_coverage:
     name: set codecov unit test coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CACHED_DEPENDENCY_PATHS: |
     ${{ github.workspace }}/.yarn/cache
+    ${{ github.workspace }}/.yarn/unplugged
   CACHED_BUILD_PATHS: ${{ github.workspace }}/.next/cache
   BUILD_CACHE_KEY: ${{ github.sha }}
   DEFAULT_NODE_VERSION: '16'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
       - name: Build
         if: steps.cache_built_packages.outputs.cache-hit == ''
         run: yarn build
+    outputs:
+      dependency_cache_key: ${{ needs.job_install_dependencies.outputs.dependency_cache_key }}
 
   job_continuous_integration:
     runs-on: ubuntu-latest
@@ -108,8 +110,7 @@ jobs:
           browser: chrome
           record: true
           config-file: cypress.config.js
-          install-command: yarn install --immutable
-          command-prefix: yarn dlx
+          install: false
           start: yarn dev
 
   job_codecov_test_coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   CACHED_DEPENDENCY_PATHS: |
     ${{ github.workspace }}/.yarn/cache
     ${{ github.workspace }}/.yarn/unplugged
-  CACHED_BUILD_PATHS: ${{ github.workspace }}/.next/cache
+  CACHED_BUILD_PATHS: ${{ github.workspace }}/.next
   BUILD_CACHE_KEY: ${{ github.sha }}
   DEFAULT_NODE_VERSION: '16'
 


### PR DESCRIPTION
- CI단계에서 반복적으로 일어나는 install 및 build에 cache를 적용
- nextjs bundle analysis pipeline 추가

example: https://github.com/getsentry/sentry-javascript/blob/master/.github/workflows/build.yml 

https://github.com/actions/cache