### PR TITLE
[FE-8] 라운드 설정 페이지를 구현하라

### DIFF
--- a/src/components/roundSet/RoundItem.test.tsx
+++ b/src/components/roundSet/RoundItem.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import RoundItem from './RoundItem';
+
+describe('RoundItem', () => {
+  const handleSelected = jest.fn();
+  const roundName = '16강';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderRoundItem = () => render((
+    <RoundItem name={roundName} isSelected={given.isSelected} onSelected={handleSelected} />
+  ));
+
+  context('isSelected가 true인 경우', () => {
+    given('isSelected', () => true);
+
+    it('border 색상이 "#EB4F27"이어야만 하며, text 색상은 "#FFFFFF"이어야만 한다', () => {
+      renderRoundItem();
+
+      expect(screen.getByText(roundName)).toHaveStyle({
+        border: '1.5px solid #EB4F27',
+        color: '#FFFFFF',
+      });
+    });
+  });
+
+  context('isSelected가 false인 경우', () => {
+    given('isSelected', () => false);
+
+    it('border 색상이 "#464646"이어야만 하며, text 색상은 "#808080"이어야만 한다', () => {
+      renderRoundItem();
+
+      expect(screen.getByText(roundName)).toHaveStyle({
+        border: '1.5px solid #464646',
+        color: '#808080',
+      });
+    });
+  });
+
+  describe('아이템을 클릭한다', () => {
+    it('클릭 이벤트가 호출되어야만 한다', () => {
+      renderRoundItem();
+
+      fireEvent.click(screen.getByText(roundName));
+
+      expect(handleSelected).toBeCalledWith(roundName);
+    });
+  });
+});

--- a/src/components/roundSet/RoundItem.tsx
+++ b/src/components/roundSet/RoundItem.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import AnimatedCheckboxIcon from '../common/AnimatedCheckboxIcon';
+
+interface RoundItemProps{
+  name: string;
+  isSelected: boolean;
+  onSelected: (name: string)=>void;
+}
+
+function RoundItem({ name, isSelected, onSelected }:RoundItemProps) {
+  const handleSelect = () => onSelected(name);
+
+  return (
+    <RoundItemWrapper onClick={handleSelect} isSelected={isSelected}>
+      {name}
+      <AnimatedCheckboxIcon isChecked={isSelected} />
+    </RoundItemWrapper>
+  );
+}
+
+export default RoundItem;
+
+const RoundItemWrapper = styled.div<{isSelected: boolean;}>`
+  display: flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  width: 320px;
+  height: 62px;
+  border-radius: 31px;
+  transition: border-color 0.2s ease-in-out;
+  border: 1.5px solid #464646;  
+  margin-bottom: 30px;
+
+  font-weight: 500;
+  font-size: 18px;
+  line-height: 22px;
+  text-align: center;
+  letter-spacing: -0.05em;
+  color: #808080;
+
+  ${({ isSelected }) => isSelected && css`
+    border: 1.5px solid #EB4F27;
+    font-weight: 700;
+    color: #FFFFFF;
+  `};
+`;

--- a/src/components/roundSet/RoundItems.test.tsx
+++ b/src/components/roundSet/RoundItems.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import RoundItems from './RoundItems';
+
+describe('RoundItems', () => {
+  const renderRoundItems = () => render((<RoundItems />));
+
+  describe('Round를 선택한다.', () => {
+    it('선택된 border 색상과 text 색상이 변경되어야만 한다', () => {
+      renderRoundItems();
+
+      const round32Element = screen.getByText('32강');
+
+      fireEvent.click(round32Element);
+
+      expect(round32Element).toHaveStyle({
+        border: '1.5px solid #EB4F27',
+        color: '#FFFFFF',
+      });
+    });
+  });
+});

--- a/src/components/roundSet/RoundItems.tsx
+++ b/src/components/roundSet/RoundItems.tsx
@@ -1,0 +1,49 @@
+import React, { useCallback, useState } from 'react';
+
+import styled from '@emotion/styled';
+
+import Button from '@/components/common/Button';
+
+import RoundItem from './RoundItem';
+
+function RoundItems() {
+  const [selectedRound, setSelectedRound] = useState<string>('');
+
+  const rounds:string[] = ['32강', '16강', '8강', '4강'];
+
+  const onSelectedRound = useCallback((name: string) => setSelectedRound(name), []);
+
+  return (
+    <>
+      <RoundItemsWrapper>
+        {rounds.map((round) => (
+          <RoundItem
+            key={round}
+            name={round}
+            isSelected={round === selectedRound}
+            onSelected={onSelectedRound}
+          />
+        ))}
+      </RoundItemsWrapper>
+      <ButtonWrapper>
+        <Button disabled={!selectedRound}>월드컵시작</Button>
+      </ButtonWrapper>
+    </>
+  );
+}
+
+export default RoundItems;
+
+const RoundItemsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 101px;
+`;
+
+const ButtonWrapper = styled.div`
+  display:flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/pages/round-set.page.tsx
+++ b/src/pages/round-set.page.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import styled from '@emotion/styled';
+
+import MobileWebLayout from '@/components/common/MobileWebLayout';
+import RoundItems from '@/components/roundSet/RoundItems';
+
+function RoundSetPage() {
+  return (
+    <MobileWebLayout>
+      <RoundSetTitle>라운드 설정</RoundSetTitle>
+      <RoundSetDescription>월드컵 라운드를 설정해주세요</RoundSetDescription>
+      <RoundItems />
+    </MobileWebLayout>
+  );
+}
+
+export default RoundSetPage;
+
+const RoundSetTitle = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 17px;
+  line-height: 20px;
+  text-align: center;
+  letter-spacing: -0.05em;
+  color: #FFFFFF;
+  margin-bottom: 94px;
+`;
+
+const RoundSetDescription = styled.div`
+  display: flex;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 24px;
+  letter-spacing: -0.05em;
+  color: #FFFFFF;
+  margin-bottom: 49px;
+`;

--- a/src/pages/round-set.test.tsx
+++ b/src/pages/round-set.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+
+import RoundSetPage from './round-set.page';
+
+describe('RoundSetPage', () => {
+  const renderRoundSetPage = () => render((
+    <RoundSetPage />
+  ));
+
+  it('"라운드 설정" 문구가 나타나야만 한다', () => {
+    const { container } = renderRoundSetPage();
+
+    expect(container).toHaveTextContent('라운드 설정');
+  });
+});


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- 라운드 설정 페이지를 구현 (진행중)

## 🎉 어떻게 해결했나요?
- /round-set

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<img width="341" alt="스크린샷 2022-08-13 오전 10 23 50" src="https://user-images.githubusercontent.com/92025050/184463356-45cbbcb7-9ef0-4db7-96c7-5a850f1df616.png">


### 🔗 Jira link
<!-- - https://dnd-7th-3.atlassian.net/browse/<티켓번호> -->
- https://dnd-7th-3.atlassian.net/browse/FE-8
 