### PR TITLE
[FE-11] 공통 헤더 레이아웃을 구현하라

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -129,5 +129,8 @@ module.exports = {
     'react/require-default-props': [2, {
       ignoreFunctionalComponents: true,
     }],
+    'jsx-a11y/anchor-is-valid': ['error', {
+      aspects: ['invalidHref'],
+    }],
   },
 };

--- a/src/components/common/MobileWebLayout.tsx
+++ b/src/components/common/MobileWebLayout.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React, { PropsWithChildren, useEffect } from 'react';
 
 import styled from '@emotion/styled';
 
 import mobileWebMQ from '@/styles/responsive';
 
-function MobileWebLayout({ children, ...rest }: PropsWithChildren<unknown>) {
+function MobileWebLayout({ children }: PropsWithChildren<unknown>) {
   const handleResize = () => {
     const vh = window.innerHeight * 0.01;
     document.documentElement.style.setProperty('--vh', `${vh}px`);
@@ -19,7 +18,7 @@ function MobileWebLayout({ children, ...rest }: PropsWithChildren<unknown>) {
   }, []);
 
   return (
-    <MobileWebLayoutWrapper {...rest}>
+    <MobileWebLayoutWrapper>
       <ContainerWrapper>
         {children}
       </ContainerWrapper>
@@ -43,6 +42,9 @@ const ContainerWrapper = styled.div`
   min-height: calc(100% - 90px);
   background-color: ${({ theme }) => theme.black};
   height: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 
   ${mobileWebMQ({
     position: [false, 'relative'],

--- a/src/components/common/NavigationHeader.test.tsx
+++ b/src/components/common/NavigationHeader.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+
+import MockTheme from '@/test/MockTheme';
+
+import NavigationHeader from './NavigationHeader';
+
+describe('NavigationHeader', () => {
+  const renderNavigationHeader = () => render((
+    <MockTheme>
+      <NavigationHeader
+        goBackHref="/"
+        nextHref={given.nextHref}
+        activeDot="menu"
+      />
+    </MockTheme>
+  ));
+
+  context('nextHref가 존재하는 경우', () => {
+    given('nextHref', () => '/filter/radius');
+
+    it('건너뛰기 링크가 나타나야만 한다', () => {
+      const { container } = renderNavigationHeader();
+
+      expect(container).toHaveTextContent('건너뛰기');
+    });
+  });
+
+  context('nextHref가 존재하지 않는 경우', () => {
+    given('nextHref', () => undefined);
+
+    it('건너뛰기 링크가 안보여야만 한다', () => {
+      const { container } = renderNavigationHeader();
+
+      expect(container).not.toHaveTextContent('건너뛰기');
+    });
+  });
+});

--- a/src/components/common/NavigationHeader.tsx
+++ b/src/components/common/NavigationHeader.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import Link from 'next/link';
+
+import { subHead1Font } from '@/styles/fontStyles';
+
+export type ActiveDot = 'menu' | 'radius' | 'roundSet';
+
+interface NavigationHeaderProps {
+  goBackHref: string;
+  nextHref?: string;
+  activeDot: ActiveDot;
+}
+
+function NavigationHeader({
+  goBackHref, nextHref, activeDot,
+}: NavigationHeaderProps) {
+  return (
+    <NavigationHeaderWrapper>
+      <Link href={goBackHref} passHref>
+        <HeaderLink className="back">
+          뒤로
+        </HeaderLink>
+      </Link>
+      <DotGroup>
+        <Dot isViewed={activeDot === 'menu'} />
+        <Dot isViewed={activeDot === 'radius'} />
+        <Dot isViewed={activeDot === 'roundSet'} />
+      </DotGroup>
+      {nextHref && (
+        <Link href={nextHref} passHref>
+          <HeaderLink className="skip">
+            건너뛰기
+          </HeaderLink>
+        </Link>
+      )}
+    </NavigationHeaderWrapper>
+  );
+}
+
+export default NavigationHeader;
+
+const NavigationHeaderWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: 24px;
+  right: 0px;
+  left: 0px;
+  width: 100%;
+`;
+
+const HeaderLink = styled.a`
+  ${subHead1Font};
+  color: ${({ theme }) => theme.main400};
+  position: absolute;
+  top: -9px;
+
+  &.back {
+    left: 24px;
+  }
+
+  &.skip {
+    right: 24px;
+  }
+`;
+
+const Dot = styled.div<{ isViewed: boolean; }>`
+  transition: background-color 0.2s ease-in-out;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+
+  ${({ isViewed, theme }) => (isViewed ? css`
+    background-color: ${theme.white};
+  ` : css`
+    background-color: ${theme.gray700};
+  `)}
+`;
+
+const DotGroup = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+
+  & > div:not(div:last-of-type) {
+    margin-right: 9px;
+  }
+`;

--- a/src/components/common/NavigationHeaderGetLayout.test.tsx
+++ b/src/components/common/NavigationHeaderGetLayout.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+
+import getNavigationHeaderLayout from './NavigationHeaderGetLayout';
+
+describe('NavigationHeaderGetLayout', () => {
+  const GetLayout = getNavigationHeaderLayout({
+    activeDot: 'menu',
+    goBackHref: '/',
+  });
+
+  function MockComponent(): JSX.Element {
+    return <>Test</>;
+  }
+
+  const renderNavigationHeaderGetLayout = () => render((
+    <>
+      {GetLayout(<MockComponent />)}
+    </>
+  ));
+
+  it('header 레이아웃에 대한 내용이 보여야만 한다', () => {
+    const { container } = renderNavigationHeaderGetLayout();
+
+    expect(container).toHaveTextContent('뒤로');
+  });
+});

--- a/src/components/common/NavigationHeaderGetLayout.tsx
+++ b/src/components/common/NavigationHeaderGetLayout.tsx
@@ -1,0 +1,22 @@
+import { ComponentProps, ReactElement } from 'react';
+
+import NavigationHeader from './NavigationHeader';
+
+const getNavigationHeaderLayout = ({
+  activeDot, goBackHref, nextHref,
+}: ComponentProps<typeof NavigationHeader>) => function NavigationHeaderGetLayout(
+  page: ReactElement,
+) {
+  return (
+    <>
+      <NavigationHeader
+        activeDot={activeDot}
+        goBackHref={goBackHref}
+        nextHref={nextHref}
+      />
+      {page}
+    </>
+  );
+};
+
+export default getNavigationHeaderLayout;

--- a/src/components/filter/LocationInformation.tsx
+++ b/src/components/filter/LocationInformation.tsx
@@ -24,7 +24,7 @@ const LocationWrapper = styled.div`
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  margin-top: 38px;
+  margin-top: 59px;
   margin-bottom: 29px;
 
   & > svg {

--- a/src/components/roundSet/RoundSet.tsx
+++ b/src/components/roundSet/RoundSet.tsx
@@ -68,4 +68,5 @@ const RoundItemsWrapper = styled.div`
 const RoundSetWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  margin-top: 104px;
 `;

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,15 +1,27 @@
-import { useState } from 'react';
+import { ReactElement, ReactNode, useState } from 'react';
 
 import { ThemeProvider } from '@emotion/react';
 import { Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 import { RecoilRoot } from 'recoil';
 
+import MobileWebLayout from '@/components/common/MobileWebLayout';
 import GlobalStyles from '@/styles/GlobalStyles';
 import lightTheme from '@/styles/theme';
 
-function MyApp({ Component: AppComponent, pageProps }: AppProps) {
+type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode;
+}
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+}
+
+function MyApp({ Component: AppComponent, pageProps }: AppPropsWithLayout) {
+  const getLayout = AppComponent.getLayout ?? ((page) => page);
+
   const [queryClient] = useState(() => new QueryClient({
     defaultOptions: {
       queries: {
@@ -25,7 +37,11 @@ function MyApp({ Component: AppComponent, pageProps }: AppProps) {
         <RecoilRoot>
           <ThemeProvider theme={lightTheme}>
             <GlobalStyles />
-            <AppComponent {...pageProps} />
+            <MobileWebLayout>
+              {getLayout((
+                <AppComponent {...pageProps} />
+              ))}
+            </MobileWebLayout>
           </ThemeProvider>
         </RecoilRoot>
         <ReactQueryDevtools initialIsOpen={false} />

--- a/src/pages/filter/menu.page.tsx
+++ b/src/pages/filter/menu.page.tsx
@@ -1,51 +1,42 @@
 import styled from '@emotion/styled';
 
 import Button from '@/components/common/Button';
-import MobileWebLayout from '@/components/common/MobileWebLayout';
+import getNavigationHeaderLayout from '@/components/common/NavigationHeaderGetLayout';
 import FoodCategories from '@/components/filter/FoodCategories';
 import LocationInformation from '@/components/filter/LocationInformation';
 import { body1Font, heading2Font } from '@/styles/fontStyles';
 
 function FilterMenuPage() {
   return (
-    <FilterMenuPageLayout>
-      <FilterMenuTitleSection>
-        <LocationInformation />
-        <Title>
-          2차에서 먹고싶은
-          <br />
-          메뉴를 선택해주세요
-        </Title>
-        <CategoryDescription>
-          여러 메뉴가 먹고싶다면 중복선택도 가능!
-        </CategoryDescription>
-        <FoodCategories />
-      </FilterMenuTitleSection>
+    <>
       <div>
-        <Button href="/filter/radius">
-          다음
-        </Button>
+        <FilterMenuTitleSection>
+          <LocationInformation />
+          <Title>
+            2차에서 먹고싶은
+            <br />
+            메뉴를 선택해주세요
+          </Title>
+          <CategoryDescription>
+            여러 메뉴가 먹고싶다면 중복선택도 가능!
+          </CategoryDescription>
+          <FoodCategories />
+        </FilterMenuTitleSection>
       </div>
-    </FilterMenuPageLayout>
+      <Button href="/filter/radius">
+        다음
+      </Button>
+    </>
   );
 }
 
 export default FilterMenuPage;
 
-const FilterMenuPageLayout = styled(MobileWebLayout)`
-  & > div {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-
-    & > div:last-of-type {
-      display: flex;
-      justify-content: center;
-      margin-top: 54px;
-      margin-bottom: 12px;
-    }
-  }
-`;
+FilterMenuPage.getLayout = getNavigationHeaderLayout({
+  activeDot: 'menu',
+  goBackHref: '/',
+  nextHref: '/filter/radius',
+});
 
 const FilterMenuTitleSection = styled.div`
   display: flex;

--- a/src/pages/filter/radius.page.tsx
+++ b/src/pages/filter/radius.page.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import Button from '@/components/common/Button';
-import MobileWebLayout from '@/components/common/MobileWebLayout';
+import getNavigationHeaderLayout from '@/components/common/NavigationHeaderGetLayout';
 import FilterItems from '@/components/filter/FilterItems';
 import LocationInformation from '@/components/filter/LocationInformation';
 import { body1Font, heading2Font } from '@/styles/fontStyles';
 
 function FilterRadiusPage() {
   return (
-    <FilterRadiusPageLayout>
+    <>
       <div>
         <FilterRadiusTileSection>
           <LocationInformation />
@@ -19,22 +19,22 @@ function FilterRadiusPage() {
         </FilterRadiusTileSection>
         <FilterItems />
       </div>
-      <Button href="/round-set">
-        다음
-      </Button>
-    </FilterRadiusPageLayout>
+      <div>
+        <Button href="/round-set">
+          다음
+        </Button>
+      </div>
+    </>
   );
 }
 
 export default FilterRadiusPage;
 
-const FilterRadiusPageLayout = styled(MobileWebLayout)`
-  & > div {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-  }
-`;
+FilterRadiusPage.getLayout = getNavigationHeaderLayout({
+  activeDot: 'radius',
+  goBackHref: '/filter/menu',
+  nextHref: '/round-set',
+});
 
 const FilterRadiusTileSection = styled.div`
   display: flex;

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import MobileWebLayout from '@/components/common/MobileWebLayout';
 import GameItem from '@/components/home/GameItem';
 import { heading3Font, subHead2Font } from '@/styles/fontStyles';
 
@@ -37,11 +36,9 @@ function IndexPage() {
 
 export default IndexPage;
 
-const IndexPageLayout = styled(MobileWebLayout)`
-  & > div {
-    & > a:first-of-type {
-      margin-bottom: 20px;
-    }
+const IndexPageLayout = styled.div`
+  & > a:first-of-type {
+    margin-bottom: 20px;
   }
 `;
 

--- a/src/pages/round-set/index.page.tsx
+++ b/src/pages/round-set/index.page.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
 
-import styled from '@emotion/styled';
-
-import MobileWebLayout from '@/components/common/MobileWebLayout';
+import getNavigationHeaderLayout from '@/components/common/NavigationHeaderGetLayout';
 import RoundSet from '@/components/roundSet/RoundSet';
 
 function RoundSetPage() {
   return (
-    <RoundSetPageLayout>
-      <RoundSet />
-    </RoundSetPageLayout>
+    <RoundSet />
   );
 }
 
-export default RoundSetPage;
+RoundSetPage.getLayout = getNavigationHeaderLayout({
+  activeDot: 'roundSet',
+  goBackHref: '/filter/radius',
+});
 
-const RoundSetPageLayout = styled(MobileWebLayout)`
-  & > div {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-  }
-`;
+export default RoundSetPage;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- 공통 헤더 레이아웃을 구현

## 🎉 어떻게 해결했나요?
- 필터 및 라운드 설정에 적용되는 헤더 레이아웃을 구현
- MobileWebLayout 컴포넌트 _app으로 공통적으로 사용되도록 변경
- NavigationHeaderGetLayout 구현으로 필요한 페이지에서 getLayout을 적용하여 공통으로 사용하도록 구현

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<img width="528" alt="image" src="https://user-images.githubusercontent.com/60910665/185456204-e92b8c61-e335-4933-b1ab-ae8055fb2f2a.png">


### 🔗 Jira link
<!-- - https://dnd-7th-3.atlassian.net/browse/<티켓번호> -->
- https://dnd-7th-3.atlassian.net/browse/FE-11
 