### PR TITLE
[FE-13] world cup api를 구현하라

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ cypress/log
 # next-pwa
 **/public/workbox**
 **/public/sw**
+
+#env
+.env

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,10 @@ const customJestConfig = {
   ],
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: 'jest-environment-jsdom',
+  coveragePathIgnorePatterns: [
+    // NOTE - 테스트를 위한 wrapper component
+    '<rootDir>/src/test/ReactQueryWrapper.tsx',
+  ],
 };
 
 module.exports = async () => ({

--- a/src/api/__mocks__/index.ts
+++ b/src/api/__mocks__/index.ts
@@ -1,0 +1,3 @@
+export const api = jest.fn();
+
+export const paramsSerializer = jest.fn();

--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -41,10 +41,12 @@ describe('getUrl', () => {
   });
 
   context('isBFF가 false인 경우', () => {
-    it('url 앞에 NEXT_PUBLIC_API_HOST가 붙어서 반환해야만 한다', () => {
+    const BASE_URL = 'http://15.164.216.101';
+
+    it('url 앞에 BASE_URL이 붙어서 반환해야만 한다', () => {
       const url = getUrl('/path');
 
-      expect(url).toBe(`${process.env.NEXT_PUBLIC_API_HOST}${path}`);
+      expect(url).toBe(`${BASE_URL}${path}`);
     });
   });
 });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,6 +3,8 @@ import qs from 'qs';
 
 import { BaseHeader, CustomAxiosRequestConfig } from '@/models/api';
 
+const BASE_URL = 'http://15.164.216.101';
+
 const baseHeaders: BaseHeader = {
   'Content-Type': 'application/json',
   Accept: 'application/json',
@@ -13,7 +15,7 @@ export const getUrl = (url: string, isBFF = false): string => {
     return `/api${url}`;
   }
 
-  return `${process.env.NEXT_PUBLIC_API_HOST}${url}`;
+  return `${BASE_URL}${url}`;
 };
 
 export const paramsSerializer = (params: any): string => qs.stringify(params, { indices: false });

--- a/src/api/worldCup/index.ts
+++ b/src/api/worldCup/index.ts
@@ -1,0 +1,11 @@
+import { api } from '..';
+
+// eslint-disable-next-line import/prefer-default-export
+export const fetchFoodWorldCup = async () => {
+  const response = await api({
+    method: 'GET',
+    url: '/worldCup',
+  });
+
+  return response;
+};

--- a/src/api/worldCup/worldCup.test.ts
+++ b/src/api/worldCup/worldCup.test.ts
@@ -1,0 +1,27 @@
+import { fetchFoodWorldCup } from '@/api/worldCup';
+
+import { api } from '..';
+
+jest.mock('..');
+
+describe('worldCup API', () => {
+  beforeEach(() => {
+    (api as jest.Mock).mockClear();
+  });
+
+  describe('fetchFoodWorldCup', () => {
+    beforeEach(() => {
+      (api as jest.Mock).mockReturnValueOnce('mock');
+    });
+
+    it('GET /worldCup', async () => {
+      const response = await fetchFoodWorldCup();
+
+      expect(api).toBeCalledWith({
+        method: 'GET',
+        url: '/worldCup',
+      });
+      expect(response).toBe('mock');
+    });
+  });
+});

--- a/src/hooks/api/useFetchFoodWorldCup.test.ts
+++ b/src/hooks/api/useFetchFoodWorldCup.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { fetchFoodWorldCup } from '@/api/worldCup';
+import wrapper from '@/test/ReactQueryWrapper';
+
+import useFetchFoodWorldCup from './useFetchFoodWorldCup';
+
+jest.mock('@/api/worldCup');
+
+describe('useFetchFoodWorldCup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (fetchFoodWorldCup as jest.Mock).mockResolvedValue('test');
+  });
+
+  const useFetchFoodWorldCupHook = () => renderHook(
+    () => useFetchFoodWorldCup(),
+    { wrapper },
+  );
+
+  it('fetchFoodWorldCup api를 호출해야만 한다.', async () => {
+    const { result, waitFor } = useFetchFoodWorldCupHook();
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(fetchFoodWorldCup).toBeCalled();
+    expect(result.current.data).toEqual('test');
+  });
+});

--- a/src/hooks/api/useFetchFoodWorldCup.ts
+++ b/src/hooks/api/useFetchFoodWorldCup.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchFoodWorldCup } from '@/api/worldCup';
+
+function useFetchFoodWorldCup() {
+  const query = useQuery(['test'], fetchFoodWorldCup);
+
+  return query;
+}
+
+export default useFetchFoodWorldCup;

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -27,6 +27,7 @@ function MyApp({ Component: AppComponent, pageProps }: AppPropsWithLayout) {
       queries: {
         retry: false,
         refetchOnWindowFocus: false,
+        suspense: true,
       },
     },
   }));


### PR DESCRIPTION

<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- world cup api를 구현하라

## 🎉 어떻게 해결했나요?
- cors에러 발생으로 정확한 response data 확인 불가능
- useFetchFoodWorldCup api hook 구현 

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

### 🔗 Jira link
<!-- - https://dnd-7th-3.atlassian.net/browse/<티켓번호> -->
- https://dnd-7th-3.atlassian.net/browse/FE-13
 