### PR TITLE
[FE-15] 월드컵 필터 상태들을 전역으로 관리하도록 변경하라

### DIFF
--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -41,12 +41,10 @@ describe('getUrl', () => {
   });
 
   context('isBFF가 false인 경우', () => {
-    const BASE_URL = 'http://15.164.216.101';
-
     it('url 앞에 BASE_URL이 붙어서 반환해야만 한다', () => {
       const url = getUrl('/path');
 
-      expect(url).toBe(`${BASE_URL}${path}`);
+      expect(url).toBe(`${process.env.NEXT_PUBLIC_API_HOST}${path}`);
     });
   });
 });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,8 +3,6 @@ import qs from 'qs';
 
 import { BaseHeader, CustomAxiosRequestConfig } from '@/models/api';
 
-const BASE_URL = 'http://15.164.216.101';
-
 const baseHeaders: BaseHeader = {
   'Content-Type': 'application/json',
   Accept: 'application/json',
@@ -15,7 +13,7 @@ export const getUrl = (url: string, isBFF = false): string => {
     return `/api${url}`;
   }
 
-  return `${BASE_URL}${url}`;
+  return `${process.env.NEXT_PUBLIC_API_HOST}${url}`;
 };
 
 export const paramsSerializer = (params: any): string => qs.stringify(params, { indices: false });

--- a/src/api/worldCup/index.ts
+++ b/src/api/worldCup/index.ts
@@ -1,10 +1,15 @@
+import { FoodWorldCup } from '@/models/worldCup';
+
 import { api } from '..';
 
+import { FoodWorldCupRequest } from './model';
+
 // eslint-disable-next-line import/prefer-default-export
-export const fetchFoodWorldCup = async () => {
-  const response = await api({
+export const fetchFoodWorldCup = async (params: FoodWorldCupRequest) => {
+  const response = await api<FoodWorldCup>({
     method: 'GET',
     url: '/worldCup',
+    params,
   });
 
   return response;

--- a/src/api/worldCup/model.ts
+++ b/src/api/worldCup/model.ts
@@ -1,0 +1,11 @@
+import { FoodWorldCup } from '@/models/worldCup';
+
+export type FoodWorldCupResponse = FoodWorldCup;
+
+export type FoodWorldCupRequest = {
+  food: string;
+  latitude: number;
+  longitude: number;
+  radius: number;
+  round: number;
+}

--- a/src/api/worldCup/worldCup.test.ts
+++ b/src/api/worldCup/worldCup.test.ts
@@ -14,12 +14,21 @@ describe('worldCup API', () => {
       (api as jest.Mock).mockReturnValueOnce('mock');
     });
 
+    const params = {
+      food: '한식',
+      latitude: 37.124,
+      longitude: 127.222,
+      radius: 1000,
+      round: 16,
+    };
+
     it('GET /worldCup', async () => {
-      const response = await fetchFoodWorldCup();
+      const response = await fetchFoodWorldCup(params);
 
       expect(api).toBeCalledWith({
         method: 'GET',
         url: '/worldCup',
+        params,
       });
       expect(response).toBe('mock');
     });

--- a/src/components/filter/FilterItems.test.tsx
+++ b/src/components/filter/FilterItems.test.tsx
@@ -1,4 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+
+import { foodWorldCupFormState } from '@/recoil/foodFilter/atom';
+import RecoilObserver from '@/test/RecoilObserver';
 
 import FilterItems from './FilterItems';
 
@@ -10,7 +14,10 @@ describe('FilterItems', () => {
   });
 
   const renderFilterItems = () => render((
-    <FilterItems onChange={handleChange} />
+    <RecoilRoot>
+      <RecoilObserver node={foodWorldCupFormState} onChange={handleChange} />
+      <FilterItems />
+    </RecoilRoot>
   ));
 
   describe('반경 slider를 조절한다', () => {
@@ -24,7 +31,13 @@ describe('FilterItems', () => {
         clientX: 14,
       });
 
-      expect(handleChange).toBeCalled();
+      expect(handleChange).toBeCalledWith({
+        food: [],
+        latitude: null,
+        longitude: null,
+        radius: 100,
+        round: null,
+      });
     });
   });
 });

--- a/src/components/filter/FilterItems.tsx
+++ b/src/components/filter/FilterItems.tsx
@@ -1,23 +1,35 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 
 import styled from '@emotion/styled';
+import { useRecoilState } from 'recoil';
 
+import { foodWorldCupFormState } from '@/recoil/foodFilter/atom';
 import { body1Font, subHead1Font } from '@/styles/fontStyles';
 import mobileWebMQ from '@/styles/responsive';
 
 import Slider from '../common/Slider';
 
-const radiusSteps = ['100m', '300m', '500m', '1km', '3km', '5km'];
+const radiusSteps = [
+  { key: 100, name: '100m' },
+  { key: 300, name: '300m' },
+  { key: 500, name: '500m' },
+  { key: 1000, name: '1km' },
+  { key: 3000, name: '3km' },
+  { key: 5000, name: '5km' },
+];
 
 interface FilterItemsProps {
   onChange?: () => void;
 }
 
 function FilterItems({ onChange }: FilterItemsProps) {
-  const [step, setStep] = useState(1);
+  const [{ radius }, setFoodWorldCupForm] = useRecoilState(foodWorldCupFormState);
 
   const handleChange = useCallback((value: number) => {
-    setStep(value);
+    setFoodWorldCupForm((prev) => ({
+      ...prev,
+      radius: radiusSteps[value].key,
+    }));
     onChange?.();
   }, []);
 
@@ -28,12 +40,12 @@ function FilterItems({ onChange }: FilterItemsProps) {
       </FilterItemTitle>
       <FilterItemContents>
         <RadiusLabel>
-          {radiusSteps.map((radius) => (
-            <div key={radius}>{radius}</div>
+          {radiusSteps.map(({ key, name }) => (
+            <div key={key}>{name}</div>
           ))}
         </RadiusLabel>
         <Slider
-          value={step}
+          value={radiusSteps.findIndex(({ key }) => key === radius)}
           onChange={handleChange}
           max={5}
         />

--- a/src/components/filter/FoodCategories.test.tsx
+++ b/src/components/filter/FoodCategories.test.tsx
@@ -1,17 +1,28 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
 
+import { foodWorldCupFormState } from '@/recoil/foodFilter/atom';
 import lightTheme from '@/styles/theme';
 import MockTheme from '@/test/MockTheme';
+import RecoilObserver from '@/test/RecoilObserver';
 
 import FoodCategories from './FoodCategories';
 
 describe('FoodCategories', () => {
   const foodEmoji = '🍲';
+  const handleChange = jest.fn();
+
+  beforeEach(() => {
+    handleChange.mockClear();
+  });
 
   const renderFoodCategories = () => render((
-    <MockTheme>
-      <FoodCategories />
-    </MockTheme>
+    <RecoilRoot>
+      <RecoilObserver node={foodWorldCupFormState} onChange={handleChange} />
+      <MockTheme>
+        <FoodCategories />
+      </MockTheme>
+    </RecoilRoot>
   ));
 
   describe('음식 카테고리를 클릭한다', () => {
@@ -27,6 +38,7 @@ describe('FoodCategories', () => {
         expect(foodCategoryItemElement).toHaveStyle({
           border: '1.5px solid transparent',
         });
+        expect(handleChange).toBeCalled();
       });
     });
 
@@ -41,6 +53,7 @@ describe('FoodCategories', () => {
         expect(foodCategoryItemElement).toHaveStyle({
           border: `1.5px solid ${lightTheme.main400}`,
         });
+        expect(handleChange).toBeCalled();
       });
     });
   });

--- a/src/components/filter/FoodCategories.tsx
+++ b/src/components/filter/FoodCategories.tsx
@@ -1,45 +1,51 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 
 import styled from '@emotion/styled';
+import { useRecoilState } from 'recoil';
+
+import { foodWorldCupFormState } from '@/recoil/foodFilter/atom';
 
 import FoodCategoryItem from './FoodCategoryItem';
 
-const foodCategory: { emoji: string; name: string }[] = [
-  { emoji: '🍲', name: '국밥 / 감자탕' },
-  { emoji: '🍖', name: '육류 / 고기' },
-  { emoji: '🍤', name: '해물 / 생선' },
-  { emoji: '🥘', name: '찌개 / 전골' },
-  { emoji: '🍡', name: '양꼬치' },
-  { emoji: '🍗', name: '치킨' },
-  { emoji: '🍺', name: '호프 / 요리주점' },
-  { emoji: '🥂', name: '바' },
-  { emoji: '🍽', name: '기타' },
+const foodCategory: { emoji: string; name: string; value: string; }[] = [
+  { emoji: '🍲', name: '국밥 / 감자탕', value: '국밥,감자탕' },
+  { emoji: '🍖', name: '육류 / 고기', value: '육류,고기' },
+  { emoji: '🍤', name: '해물 / 생선', value: '해물,생선' },
+  { emoji: '🥘', name: '찌개 / 전골', value: '찌개,전골' },
+  { emoji: '🍡', name: '양꼬치', value: '양꼬치' },
+  { emoji: '🍗', name: '치킨', value: '치킨' },
+  { emoji: '🍺', name: '호프 / 요리주점', value: '호프,요리주점' },
+  { emoji: '🥂', name: '바', value: '바' },
+  { emoji: '🍽', name: '기타', value: '기타' },
 ];
 
 function FoodCategories() {
-  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [{ food }, setFoodWorldCupForm] = useRecoilState(foodWorldCupFormState);
 
   const onSelectedCategory = useCallback((selectedCategory: string) => {
-    if (selectedCategories.includes(selectedCategory)) {
-      setSelectedCategories((
-        prevSelectedCategories,
-      ) => prevSelectedCategories.filter((category) => category !== selectedCategory));
+    if (food.includes(selectedCategory)) {
+      setFoodWorldCupForm((prev) => ({
+        ...prev,
+        food: prev.food.filter((category) => category !== selectedCategory),
+      }));
       return;
     }
 
-    setSelectedCategories((prevSelectedCategories) => [
-      ...prevSelectedCategories, selectedCategory,
-    ]);
-  }, [selectedCategories]);
+    setFoodWorldCupForm((prev) => ({
+      ...prev,
+      food: [...prev.food, selectedCategory],
+    }));
+  }, [food]);
 
   return (
     <FoodCategoryWrapper>
-      {foodCategory.map(({ emoji, name }) => (
+      {foodCategory.map(({ emoji, name, value }) => (
         <FoodCategoryItem
-          key={name}
-          isSelected={selectedCategories.includes(name)}
+          key={value}
+          isSelected={food.includes(value)}
           onSelected={onSelectedCategory}
           emoji={emoji}
+          value={value}
           name={name}
         />
       ))}

--- a/src/components/filter/FoodCategoryItem.test.tsx
+++ b/src/components/filter/FoodCategoryItem.test.tsx
@@ -17,6 +17,7 @@ describe('FoodCategoryItem', () => {
     <MockTheme>
       <FoodCategoryItem
         emoji="🍚"
+        value="한식"
         name={foodName}
         isSelected={given.isSelected}
         onSelected={handleSelected}

--- a/src/components/filter/FoodCategoryItem.tsx
+++ b/src/components/filter/FoodCategoryItem.tsx
@@ -10,14 +10,15 @@ import AnimatedCheckboxIcon from '../common/AnimatedCheckboxIcon';
 interface FoodCategoryItemProps {
   name: string;
   emoji: string;
+  value: string;
   isSelected: boolean;
-  onSelected: (name: string) => void;
+  onSelected: (value: string) => void;
 }
 
 function FoodCategoryItem({
-  name, emoji, isSelected, onSelected,
+  name, emoji, isSelected, onSelected, value,
 }: FoodCategoryItemProps) {
-  const handleSelect = () => onSelected(name);
+  const handleSelect = () => onSelected(value);
 
   return (
     <FoodCategoryItemWrapper>

--- a/src/components/filter/LocationInformation.test.tsx
+++ b/src/components/filter/LocationInformation.test.tsx
@@ -1,6 +1,7 @@
 import { useGeolocation } from 'react-use';
 
 import { render } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
 
 import LocationInformation from './LocationInformation';
 
@@ -48,7 +49,9 @@ describe('LocationInformation', () => {
   });
 
   const renderLocationInformation = () => render((
-    <LocationInformation />
+    <RecoilRoot>
+      <LocationInformation />
+    </RecoilRoot>
   ));
 
   context('위치정보 api가 로딩중인 경우', () => {

--- a/src/components/filter/LocationInformation.tsx
+++ b/src/components/filter/LocationInformation.tsx
@@ -2,7 +2,9 @@ import React, { useEffect, useState } from 'react';
 import { useGeolocation } from 'react-use';
 
 import styled from '@emotion/styled';
+import { useSetRecoilState } from 'recoil';
 
+import { foodWorldCupFormState } from '@/recoil/foodFilter/atom';
 import { captionFont } from '@/styles/fontStyles';
 import { checkNumNull, emptyAThenB } from '@/utils/utils';
 
@@ -11,16 +13,25 @@ import LocationDotIcon from '../../assets/icons/location.svg';
 function LocationInformation() {
   const geolocation = useGeolocation();
   const [currentLocation, setCurrentLocation] = useState<string>('');
+  const setFoodWorldCupForm = useSetRecoilState(foodWorldCupFormState);
 
   useEffect(() => {
-    if (geolocation.loading) {
+    const { loading, latitude, longitude } = geolocation;
+
+    if (loading) {
       setCurrentLocation('로딩중...');
       return;
     }
 
-    naver.maps.Service.reverseGeocode({
+    setFoodWorldCupForm((prev) => ({
+      ...prev,
+      latitude,
+      longitude,
+    }));
+
+    naver?.maps?.Service?.reverseGeocode({
       coords: new naver
-        .maps.LatLng(checkNumNull(geolocation.latitude), checkNumNull(geolocation.longitude)),
+        .maps.LatLng(checkNumNull(latitude), checkNumNull(longitude)),
     }, (status, response) => {
       if (status !== naver.maps.Service.Status.OK) {
         setCurrentLocation('');

--- a/src/components/roundSet/RoundItem.test.tsx
+++ b/src/components/roundSet/RoundItem.test.tsx
@@ -8,6 +8,7 @@ import RoundItem from './RoundItem';
 describe('RoundItem', () => {
   const handleSelected = jest.fn();
   const roundName = '16강';
+  const round = 16;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -16,6 +17,7 @@ describe('RoundItem', () => {
   const renderRoundItem = () => render((
     <MockTheme>
       <RoundItem
+        value={round}
         name={roundName}
         selectedRound={given.selectedRound}
         onSelected={handleSelected}
@@ -24,8 +26,8 @@ describe('RoundItem', () => {
   ));
 
   context('selectedRound가 존재하는 경우', () => {
-    context('"name"과 "selectedRound"가 일치하는 경우', () => {
-      given('selectedRound', () => roundName);
+    context('"value"와 "selectedRound"가 일치하는 경우', () => {
+      given('selectedRound', () => round);
 
       it(`border 색상이 "${lightTheme.main400}"이어야만 하며, text 색상은 "${lightTheme.main400}"이어야만 한다`, () => {
         renderRoundItem();
@@ -37,8 +39,8 @@ describe('RoundItem', () => {
       });
     });
 
-    context('"name"과 "selectedRound"가 일치하지 않는 경우', () => {
-      given('selectedRound', () => '4강');
+    context('"value"와 "selectedRound"가 일치하지 않는 경우', () => {
+      given('selectedRound', () => 4);
 
       it('opacity 속성이 "0.6"이어야만 한다', () => {
         renderRoundItem();
@@ -68,7 +70,7 @@ describe('RoundItem', () => {
 
       fireEvent.click(screen.getByText(roundName));
 
-      expect(handleSelected).toBeCalledWith(roundName);
+      expect(handleSelected).toBeCalledWith(round);
     });
   });
 });

--- a/src/components/roundSet/RoundItem.tsx
+++ b/src/components/roundSet/RoundItem.tsx
@@ -9,13 +9,16 @@ import AnimatedCheckboxIcon from '../common/AnimatedCheckboxIcon';
 
 interface RoundItemProps{
   name: string;
-  selectedRound?: string;
-  onSelected: (name: string)=>void;
+  value: number;
+  selectedRound: number | null;
+  onSelected: (round: number) => void;
 }
 
-function RoundItem({ name, selectedRound, onSelected }:RoundItemProps) {
-  const handleSelect = () => onSelected(name);
-  const isSelected = selectedRound === name;
+function RoundItem({
+  name, selectedRound, value, onSelected,
+}:RoundItemProps) {
+  const handleSelect = () => onSelected(value);
+  const isSelected = selectedRound === value;
 
   return (
     <RoundItemWrapper
@@ -33,7 +36,7 @@ function RoundItem({ name, selectedRound, onSelected }:RoundItemProps) {
 
 export default memo(RoundItem);
 
-const RoundItemWrapper = styled.div<{ isSelected: boolean; selectedRound?: string; }>`
+const RoundItemWrapper = styled.div<{ isSelected: boolean; selectedRound: number | null; }>`
   ${subHead2Font};
   cursor: pointer;
   user-select: none;

--- a/src/components/roundSet/RoundSet.test.tsx
+++ b/src/components/roundSet/RoundSet.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
 
 import lightTheme from '@/styles/theme';
 import MockTheme from '@/test/MockTheme';
@@ -7,20 +8,22 @@ import RoundSet from './RoundSet';
 
 describe('RoundSet', () => {
   const renderRoundSet = () => render((
-    <MockTheme>
-      <RoundSet />
-    </MockTheme>
+    <RecoilRoot>
+      <MockTheme>
+        <RoundSet />
+      </MockTheme>
+    </RecoilRoot>
   ));
 
   describe('Round를 선택한다.', () => {
     it('선택된 border 색상과 text 색상이 변경되어야만 한다', () => {
       renderRoundSet();
 
-      const round32Element = screen.getByText('32강');
+      const round16Element = screen.getByText('16강');
 
-      fireEvent.click(round32Element);
+      fireEvent.click(round16Element);
 
-      expect(round32Element).toHaveStyle({
+      expect(round16Element).toHaveStyle({
         border: `1.5px solid ${lightTheme.main400}`,
         color: `${lightTheme.main400}`,
       });
@@ -29,7 +32,7 @@ describe('RoundSet', () => {
     it('"게임 시작" 버튼이 나타나야만 한다', () => {
       const { container } = renderRoundSet();
 
-      fireEvent.click(screen.getByText('32강'));
+      fireEvent.click(screen.getByText('16강'));
 
       expect(container).toHaveTextContent('게임 시작');
     });

--- a/src/components/roundSet/RoundSet.tsx
+++ b/src/components/roundSet/RoundSet.tsx
@@ -1,18 +1,27 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 
 import styled from '@emotion/styled';
+import { useRecoilState } from 'recoil';
 
 import Button from '@/components/common/Button';
+import { foodWorldCupFormState } from '@/recoil/foodFilter/atom';
 import { body1Font, heading2Font } from '@/styles/fontStyles';
 
 import RoundItem from './RoundItem';
 
+const rounds = [
+  { key: 4, name: '4강' },
+  { key: 8, name: '8강' },
+  { key: 16, name: '16강' },
+];
+
 function RoundSet() {
-  const [selectedRound, setSelectedRound] = useState<string>();
+  const [{ round }, setFoodWorldCupForm] = useRecoilState(foodWorldCupFormState);
 
-  const rounds: string[] = ['4강', '8강', '16강', '32강'];
-
-  const onSelectedRound = useCallback((name: string) => setSelectedRound(name), []);
+  const onSelectedRound = useCallback((selectedRound: number) => setFoodWorldCupForm((prev) => ({
+    ...prev,
+    round: selectedRound,
+  })), []);
 
   return (
     <>
@@ -20,17 +29,18 @@ function RoundSet() {
         <RoundSetTitle>라운드를 설정해주세요</RoundSetTitle>
         <RoundSetDescription>진행하고싶은 월드컵 라운드를 선택해주세요</RoundSetDescription>
         <RoundItemsWrapper>
-          {rounds.map((round) => (
+          {rounds.map(({ key, name }) => (
             <RoundItem
-              key={round}
-              name={round}
-              selectedRound={selectedRound}
+              key={key}
+              name={name}
+              value={key}
+              selectedRound={round}
               onSelected={onSelectedRound}
             />
           ))}
         </RoundItemsWrapper>
       </RoundSetWrapper>
-      {selectedRound && (
+      {round && (
         <Button type="button">게임 시작</Button>
       )}
     </>

--- a/src/hooks/api/useFetchFoodWorldCup.test.ts
+++ b/src/hooks/api/useFetchFoodWorldCup.test.ts
@@ -14,8 +14,16 @@ describe('useFetchFoodWorldCup', () => {
     (fetchFoodWorldCup as jest.Mock).mockResolvedValue('test');
   });
 
+  const requestForm = {
+    food: '한식',
+    latitude: 37.124,
+    longitude: 127.222,
+    radius: 1000,
+    round: 16,
+  };
+
   const useFetchFoodWorldCupHook = () => renderHook(
-    () => useFetchFoodWorldCup(),
+    () => useFetchFoodWorldCup(requestForm),
     { wrapper },
   );
 
@@ -24,7 +32,7 @@ describe('useFetchFoodWorldCup', () => {
 
     await waitFor(() => result.current.isSuccess);
 
-    expect(fetchFoodWorldCup).toBeCalled();
+    expect(fetchFoodWorldCup).toBeCalledWith(requestForm);
     expect(result.current.data).toEqual('test');
   });
 });

--- a/src/hooks/api/useFetchFoodWorldCup.ts
+++ b/src/hooks/api/useFetchFoodWorldCup.ts
@@ -1,9 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { fetchFoodWorldCup } from '@/api/worldCup';
+import { FoodWorldCupRequest } from '@/api/worldCup/model';
 
-function useFetchFoodWorldCup() {
-  const query = useQuery(['test'], fetchFoodWorldCup);
+function useFetchFoodWorldCup(request: FoodWorldCupRequest) {
+  const query = useQuery(['foodWorldCup', request], () => fetchFoodWorldCup(request), {
+    staleTime: Infinity,
+    cacheTime: Infinity,
+  });
 
   return query;
 }

--- a/src/models/worldCup.ts
+++ b/src/models/worldCup.ts
@@ -1,0 +1,33 @@
+interface FoodWorldCupDocument {
+  address_name: string;
+  category_group_code: string;
+  category_group_name: string;
+  category_name: string;
+  distance: string;
+  id: string;
+  img_url: string[];
+  phone: string;
+  place_name: string;
+  place_url: string;
+  review: number;
+  road_address_name: string;
+  tag: string;
+  x: string;
+  y: string;
+}
+
+interface Meta {
+  is_end: boolean;
+  pageable_count: number;
+  same_name: null | {
+    keyword: string;
+    region: string[];
+    selected_region: string;
+  }
+  total_count: number;
+}
+
+export interface FoodWorldCup {
+  document: FoodWorldCupDocument;
+  meta: Meta;
+}

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -27,7 +27,6 @@ function MyApp({ Component: AppComponent, pageProps }: AppPropsWithLayout) {
       queries: {
         retry: false,
         refetchOnWindowFocus: false,
-        suspense: true,
       },
     },
   }));

--- a/src/pages/filter/menu.test.tsx
+++ b/src/pages/filter/menu.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
 
 import FilterMenuPage from './menu.page';
 
@@ -9,7 +10,9 @@ jest.mock('@/components/filter/LocationInformation', () => ({
 
 describe('FilterMenuPage', () => {
   const renderFilterMenuPage = () => render((
-    <FilterMenuPage />
+    <RecoilRoot>
+      <FilterMenuPage />
+    </RecoilRoot>
   ));
 
   it('"메뉴를 선택해주세요"문구가 나타나야만 한다', () => {

--- a/src/pages/filter/radius.test.tsx
+++ b/src/pages/filter/radius.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
 
 import FilterRadiusPage from './radius.page';
 
@@ -9,7 +10,9 @@ jest.mock('@/components/filter/LocationInformation', () => ({
 
 describe('FilterRadiusPage', () => {
   const renderFilterRadiusPage = () => render((
-    <FilterRadiusPage />
+    <RecoilRoot>
+      <FilterRadiusPage />
+    </RecoilRoot>
   ));
 
   it('"거리를 설정해주세요" 문구가 나타나야만 한다', () => {

--- a/src/pages/round-set/index.test.tsx
+++ b/src/pages/round-set/index.test.tsx
@@ -1,10 +1,13 @@
 import { render } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
 
 import RoundSetPage from './index.page';
 
 describe('RoundSetPage', () => {
   const renderRoundSetPage = () => render((
-    <RoundSetPage />
+    <RecoilRoot>
+      <RoundSetPage />
+    </RecoilRoot>
   ));
 
   it('"라운드를 설정해주세요" 문구가 나타나야만 한다', () => {

--- a/src/recoil/foodFilter/atom.ts
+++ b/src/recoil/foodFilter/atom.ts
@@ -1,0 +1,21 @@
+/* eslint-disable import/prefer-default-export */
+import { atom } from 'recoil';
+
+type FoodWorldCupForm = {
+  food: string[];
+  latitude: number | null;
+  longitude: number | null;
+  radius: number;
+  round: number | null;
+}
+
+export const foodWorldCupFormState = atom<FoodWorldCupForm>({
+  key: 'foodWorldCupFormState',
+  default: {
+    food: [],
+    latitude: null,
+    longitude: null,
+    radius: 300,
+    round: null,
+  },
+});


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- 월드컵 필터 상태들을 전역으로 관리하도록 변경

## 🎉 어떻게 해결했나요?
- 필터 상태들을 전역으로 관리하도록 수정
- world cup api response request 타입 정의

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

### 🔗 Jira link
<!-- - https://dnd-7th-3.atlassian.net/browse/<티켓번호> -->
- https://dnd-7th-3.atlassian.net/browse/FE-15
 