### PR TITLE
[FE-16] 음식점 api 연결 및 호출하라

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ cypress/log
 #env
 .env
 
-test.js
+testData.js

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ cypress/log
 
 #env
 .env
+
+test.js

--- a/src/api/worldCup/index.ts
+++ b/src/api/worldCup/index.ts
@@ -12,5 +12,5 @@ export const fetchFoodWorldCup = async (params: FoodWorldCupRequest) => {
     params,
   });
 
-  return response;
+  return response.documents;
 };

--- a/src/api/worldCup/worldCup.test.ts
+++ b/src/api/worldCup/worldCup.test.ts
@@ -1,4 +1,5 @@
 import { fetchFoodWorldCup } from '@/api/worldCup';
+import FIXTURE_FOOD_WORLD_CUP_ITEM from '@/fixtures/foodWorldCupItem';
 
 import { api } from '..';
 
@@ -11,7 +12,9 @@ describe('worldCup API', () => {
 
   describe('fetchFoodWorldCup', () => {
     beforeEach(() => {
-      (api as jest.Mock).mockReturnValueOnce('mock');
+      (api as jest.Mock).mockReturnValueOnce({
+        documents: [FIXTURE_FOOD_WORLD_CUP_ITEM],
+      });
     });
 
     const params = {
@@ -30,7 +33,7 @@ describe('worldCup API', () => {
         url: '/worldCup',
         params,
       });
-      expect(response).toBe('mock');
+      expect(response).toEqual([FIXTURE_FOOD_WORLD_CUP_ITEM]);
     });
   });
 });

--- a/src/components/filter/FilterItems.test.tsx
+++ b/src/components/filter/FilterItems.test.tsx
@@ -33,8 +33,8 @@ describe('FilterItems', () => {
 
       expect(handleChange).toBeCalledWith({
         food: [],
-        latitude: null,
-        longitude: null,
+        latitude: 0,
+        longitude: 0,
         radius: 100,
         round: null,
       });

--- a/src/components/filter/FilterItems.tsx
+++ b/src/components/filter/FilterItems.tsx
@@ -18,11 +18,7 @@ const radiusSteps = [
   { key: 5000, name: '5km' },
 ];
 
-interface FilterItemsProps {
-  onChange?: () => void;
-}
-
-function FilterItems({ onChange }: FilterItemsProps) {
+function FilterItems() {
   const [{ radius }, setFoodWorldCupForm] = useRecoilState(foodWorldCupFormState);
 
   const handleChange = useCallback((value: number) => {
@@ -30,7 +26,6 @@ function FilterItems({ onChange }: FilterItemsProps) {
       ...prev,
       radius: radiusSteps[value].key,
     }));
-    onChange?.();
   }, []);
 
   return (

--- a/src/components/filter/LocationInformation.tsx
+++ b/src/components/filter/LocationInformation.tsx
@@ -1,25 +1,35 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useGeolocation } from 'react-use';
 
 import styled from '@emotion/styled';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 
+import { currentAddressState } from '@/recoil/currentLocation/atom';
 import { foodWorldCupFormState } from '@/recoil/foodFilter/atom';
 import { captionFont } from '@/styles/fontStyles';
-import { checkNumNull, emptyAThenB } from '@/utils/utils';
+import { emptyAThenB } from '@/utils/utils';
 
 import LocationDotIcon from '../../assets/icons/location.svg';
 
 function LocationInformation() {
   const geolocation = useGeolocation();
-  const [currentLocation, setCurrentLocation] = useState<string>('');
-  const setFoodWorldCupForm = useSetRecoilState(foodWorldCupFormState);
+  const [currentAddress, setCurrentAddress] = useRecoilState(currentAddressState);
+  const [foodWorldCupForm, setFoodWorldCupForm] = useRecoilState(foodWorldCupFormState);
 
   useEffect(() => {
     const { loading, latitude, longitude } = geolocation;
 
+    if (foodWorldCupForm.latitude && foodWorldCupForm.longitude) {
+      return;
+    }
+
     if (loading) {
-      setCurrentLocation('로딩중...');
+      setCurrentAddress('로딩중...');
+      return;
+    }
+
+    if (!latitude || !longitude) {
+      setCurrentAddress('');
       return;
     }
 
@@ -31,23 +41,23 @@ function LocationInformation() {
 
     naver?.maps?.Service?.reverseGeocode({
       coords: new naver
-        .maps.LatLng(checkNumNull(latitude), checkNumNull(longitude)),
+        .maps.LatLng(latitude, longitude),
     }, (status, response) => {
       if (status !== naver.maps.Service.Status.OK) {
-        setCurrentLocation('');
+        setCurrentAddress('');
         return;
       }
 
       const { v2: { address } } = response;
 
-      setCurrentLocation(emptyAThenB(address.jibunAddress, address.roadAddress));
+      setCurrentAddress(emptyAThenB(address.jibunAddress, address.roadAddress));
     });
   }, [geolocation]);
 
   return (
     <LocationWrapper>
       <LocationDotIcon />
-      <div>{emptyAThenB('위치정보없음', currentLocation)}</div>
+      <div>{emptyAThenB('위치정보없음', currentAddress)}</div>
     </LocationWrapper>
   );
 }

--- a/src/fixtures/foodWorldCupItem.ts
+++ b/src/fixtures/foodWorldCupItem.ts
@@ -1,0 +1,23 @@
+import { FoodWorldCupDocument } from '@/models/worldCup';
+
+const foodWorldCupItem: FoodWorldCupDocument = {
+  address_name: '서울 광진구 화양동 36-59',
+  category_group_code: 'FD6',
+  category_group_name: '음식점',
+  category_name: '음식점 > 한식 > 해물,생선 > 조개',
+  distance: '92.61883047813836',
+  id: '1247067489',
+  phone: '',
+  place_name: '초입',
+  place_url: 'http://place.map.kakao.com/1247067489',
+  road_address_name: '서울 광진구 동일로24길 29',
+  x: '127.06682966549721',
+  y: '37.54366960152402',
+  review: 581,
+  img_url: [
+    'https://d12zq4w4guyljn.cloudfront.net/300_300_20220616070115_photo1_784925071b2a.jpg',
+  ],
+  tag: '#혼밥, #캐주얼한, #바테이블',
+};
+
+export default foodWorldCupItem;

--- a/src/hooks/api/useFetchFoodWorldCup.test.ts
+++ b/src/hooks/api/useFetchFoodWorldCup.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 
 import { fetchFoodWorldCup } from '@/api/worldCup';
+import FIXTURE_FOOD_WORLD_CUP_ITEM from '@/fixtures/foodWorldCupItem';
 import wrapper from '@/test/ReactQueryWrapper';
 
 import useFetchFoodWorldCup from './useFetchFoodWorldCup';
@@ -11,19 +12,19 @@ describe('useFetchFoodWorldCup', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (fetchFoodWorldCup as jest.Mock).mockResolvedValue('test');
+    (fetchFoodWorldCup as jest.Mock).mockResolvedValue([FIXTURE_FOOD_WORLD_CUP_ITEM]);
   });
 
   const requestForm = {
-    food: '한식',
-    latitude: 37.124,
-    longitude: 127.222,
+    food: ['한식'],
+    latitude: 37.5429123,
+    longitude: 127.0672672,
     radius: 1000,
     round: 16,
   };
 
   const useFetchFoodWorldCupHook = () => renderHook(
-    () => useFetchFoodWorldCup(requestForm),
+    () => useFetchFoodWorldCup(requestForm, true),
     { wrapper },
   );
 
@@ -32,7 +33,10 @@ describe('useFetchFoodWorldCup', () => {
 
     await waitFor(() => result.current.isSuccess);
 
-    expect(fetchFoodWorldCup).toBeCalledWith(requestForm);
-    expect(result.current.data).toEqual('test');
+    expect(fetchFoodWorldCup).toBeCalledWith({
+      ...requestForm,
+      food: requestForm.food.join('|'),
+    });
+    expect(result.current.data).toEqual([FIXTURE_FOOD_WORLD_CUP_ITEM]);
   });
 });

--- a/src/hooks/api/useFetchFoodWorldCup.ts
+++ b/src/hooks/api/useFetchFoodWorldCup.ts
@@ -1,15 +1,29 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { fetchFoodWorldCup } from '@/api/worldCup';
-import { FoodWorldCupRequest } from '@/api/worldCup/model';
+import { FoodWorldCupForm } from '@/recoil/foodFilter/atom';
+import { checkEmpty, checkNumNull } from '@/utils/utils';
 
-function useFetchFoodWorldCup(request: FoodWorldCupRequest) {
-  const query = useQuery(['foodWorldCup', request], () => fetchFoodWorldCup(request), {
+function useFetchFoodWorldCup(form: FoodWorldCupForm, enabled = false) {
+  const requestForm = {
+    ...form,
+    // TODO - 삭제 테스트용
+    latitude: 37.5429123,
+    longitude: 127.0672672,
+    food: form.food.join('|'),
+    round: checkNumNull(form.round),
+  };
+
+  const query = useQuery(['foodWorldCup', requestForm], () => fetchFoodWorldCup(requestForm), {
     staleTime: Infinity,
     cacheTime: Infinity,
+    enabled,
   });
 
-  return query;
+  return {
+    ...query,
+    data: checkEmpty(query.data),
+  };
 }
 
 export default useFetchFoodWorldCup;

--- a/src/hooks/api/useFetchFoodWorldCup.ts
+++ b/src/hooks/api/useFetchFoodWorldCup.ts
@@ -4,7 +4,7 @@ import { fetchFoodWorldCup } from '@/api/worldCup';
 import { FoodWorldCupForm } from '@/recoil/foodFilter/atom';
 import { checkEmpty, checkNumNull } from '@/utils/utils';
 
-function useFetchFoodWorldCup(form: FoodWorldCupForm, enabled = false) {
+function useFetchFoodWorldCup(form: FoodWorldCupForm, enabled: boolean) {
   const requestForm = {
     ...form,
     // TODO - 삭제 테스트용

--- a/src/models/worldCup.ts
+++ b/src/models/worldCup.ts
@@ -1,4 +1,4 @@
-interface FoodWorldCupDocument {
+export interface FoodWorldCupDocument {
   address_name: string;
   category_group_code: string;
   category_group_name: string;
@@ -28,6 +28,6 @@ interface Meta {
 }
 
 export interface FoodWorldCup {
-  document: FoodWorldCupDocument;
+  documents: FoodWorldCupDocument[];
   meta: Meta;
 }

--- a/src/pages/round-set/index.test.tsx
+++ b/src/pages/round-set/index.test.tsx
@@ -1,13 +1,17 @@
 import { render } from '@testing-library/react';
 import { RecoilRoot } from 'recoil';
 
+import ReactQueryWrapper from '@/test/ReactQueryWrapper';
+
 import RoundSetPage from './index.page';
 
 describe('RoundSetPage', () => {
   const renderRoundSetPage = () => render((
-    <RecoilRoot>
-      <RoundSetPage />
-    </RecoilRoot>
+    <ReactQueryWrapper>
+      <RecoilRoot>
+        <RoundSetPage />
+      </RecoilRoot>
+    </ReactQueryWrapper>
   ));
 
   it('"라운드를 설정해주세요" 문구가 나타나야만 한다', () => {

--- a/src/pages/world-cup/index.page.tsx
+++ b/src/pages/world-cup/index.page.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import styled from '@emotion/styled';
+
+function WorldCupPage() {
+  // TODO
+  // const worldCupItems = useRecoilValue(worldCupState);
+  // const foodWorldCupForm = useRecoilValue(foodWorldCupFormState);
+
+  return (
+    <>
+      <WorldCupHeader>
+        <div>
+          16강
+        </div>
+        <div>
+          8강
+        </div>
+        <div>
+          4강
+        </div>
+        <div>
+          FINAL
+        </div>
+      </WorldCupHeader>
+      <WorldCupItem />
+    </>
+  );
+}
+
+export default WorldCupPage;
+
+const WorldCupHeader = styled.div`
+  color: ${({ theme }) => theme.white};
+`;
+
+const WorldCupItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 60vw;
+  max-height: 300px;
+  min-height: 217px;
+  width: 100%;
+  min-width: 300px;
+  background-color: ${({ theme }) => theme.gray900};
+  border-radius: 25px;
+`;

--- a/src/pages/world-cup/index.test.tsx
+++ b/src/pages/world-cup/index.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+
+import WorldCupPage from './index.page';
+
+describe('WorldCupPage', () => {
+  const renderWorldCupPage = () => render((
+    <RecoilRoot>
+      <WorldCupPage />
+    </RecoilRoot>
+  ));
+
+  it('월드컵에 대한 내용이 나타나야만 한다', () => {
+    const { container } = renderWorldCupPage();
+
+    expect(container).toHaveTextContent('16강');
+  });
+});

--- a/src/recoil/currentLocation/atom.ts
+++ b/src/recoil/currentLocation/atom.ts
@@ -1,0 +1,7 @@
+/* eslint-disable import/prefer-default-export */
+import { atom } from 'recoil';
+
+export const currentAddressState = atom<string>({
+  key: 'currentAddressState',
+  default: '',
+});

--- a/src/recoil/foodFilter/atom.ts
+++ b/src/recoil/foodFilter/atom.ts
@@ -1,10 +1,10 @@
 /* eslint-disable import/prefer-default-export */
 import { atom } from 'recoil';
 
-type FoodWorldCupForm = {
+export type FoodWorldCupForm = {
   food: string[];
-  latitude: number | null;
-  longitude: number | null;
+  latitude: number;
+  longitude: number;
   radius: number;
   round: number | null;
 }
@@ -13,8 +13,8 @@ export const foodWorldCupFormState = atom<FoodWorldCupForm>({
   key: 'foodWorldCupFormState',
   default: {
     food: [],
-    latitude: null,
-    longitude: null,
+    latitude: 0,
+    longitude: 0,
     radius: 300,
     round: null,
   },

--- a/src/recoil/worldCup/atom.ts
+++ b/src/recoil/worldCup/atom.ts
@@ -1,0 +1,8 @@
+/* eslint-disable import/prefer-default-export */
+import { atom } from 'recoil';
+
+import { FoodWorldCupDocument } from '@/models/worldCup';
+
+export const worldCupState = atom<FoodWorldCupDocument[]>({
+  key: 'worldCupState',
+});

--- a/src/test/InjectTestingRecoil.tsx
+++ b/src/test/InjectTestingRecoil.tsx
@@ -1,0 +1,38 @@
+import { PropsWithChildren, ReactElement } from 'react';
+
+import { MutableSnapshot, RecoilRoot } from 'recoil';
+
+import { currentAddressState } from '@/recoil/currentLocation/atom';
+import { FoodWorldCupForm, foodWorldCupFormState } from '@/recoil/foodFilter/atom';
+
+interface Props {
+  foodWorldCupForm?: FoodWorldCupForm;
+  currentAddress?: string;
+}
+
+const initialFoodWorldCupForm = {
+  food: [],
+  latitude: 0,
+  longitude: 0,
+  radius: 300,
+  round: null,
+};
+
+function InjectTestingRecoil({
+  foodWorldCupForm = initialFoodWorldCupForm,
+  currentAddress = '',
+  children,
+}: PropsWithChildren<Props>): ReactElement {
+  return (
+    <RecoilRoot
+      initializeState={({ set }: MutableSnapshot): void => {
+        set(foodWorldCupFormState, foodWorldCupForm);
+        set(currentAddressState, currentAddress);
+      }}
+    >
+      {children}
+    </RecoilRoot>
+  );
+}
+
+export default InjectTestingRecoil;

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,4 +1,7 @@
-import { checkNull, checkNumNull, emptyAThenB } from './utils';
+import {
+  checkEmpty,
+  checkNull, checkNumNull, convertToNumber, emptyAThenB,
+} from './utils';
 
 describe('checkNull', () => {
   context('value가 null일 경우', () => {
@@ -54,6 +57,52 @@ describe('emptyAThenB', () => {
       const result = emptyAThenB(b, a);
 
       expect(result).toBe(a);
+    });
+  });
+});
+
+describe('convertToNumber', () => {
+  context('null 또는 undefined인 경우', () => {
+    it('0을 반환해야만 한다', () => {
+      const result = convertToNumber();
+
+      expect(result).toBe(0);
+    });
+  });
+
+  context('숫자가 아닌 문자열인 경우', () => {
+    it('0을 반환해야만 한다', () => {
+      const result = convertToNumber('test');
+
+      expect(result).toBe(0);
+    });
+  });
+
+  context('숫자인 문자열인 경우', () => {
+    it('숫자로 변환된 형태를 반환해야만 한다', () => {
+      const result = convertToNumber('100');
+
+      expect(result).toBe(100);
+    });
+  });
+});
+
+describe('checkEmpty', () => {
+  context('value가 undefined이거나 빈 배열인 경우', () => {
+    it('빈 배열을 반환해야만 한다', () => {
+      const result = checkEmpty();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  context('value가 undefined이거나 빈 배열이 아닌 경우', () => {
+    const mockArray = ['test', 'test2'];
+
+    it('입력된 값이 반환되어야 한다', () => {
+      const result = checkEmpty(mockArray);
+
+      expect(result).toEqual(mockArray);
     });
   });
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -15,3 +15,25 @@ export const checkNumNull = (value?: number | null): number => {
 };
 
 export const emptyAThenB = <T>(b: T, a?: T | null) => a || b;
+
+export const convertToNumber = (value?: string | null) => {
+  if (!value) {
+    return 0;
+  }
+
+  const number = Number(value);
+
+  if (typeof number !== 'number' || Number.isNaN(number)) {
+    return 0;
+  }
+
+  return number;
+};
+
+export const checkEmpty = <T>(value?: T[]): T[] => {
+  if (!value || !value.length) {
+    return [];
+  }
+
+  return value;
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- 음식점 api 연결 및 호출하라

## 🎉 어떻게 해결했나요?
- food word cup data 전역으로 관리하도록 하기
- convertToNumber, checkEmpty util함수 생성
- 현재 위치 전역으로 관리
- 게임 시작 클릭시 fetching 후 /world-cup으로 이동

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

### 🔗 Jira link
<!-- - https://dnd-7th-3.atlassian.net/browse/<티켓번호> -->
- https://dnd-7th-3.atlassian.net/browse/FE-16
 