### PR TITLE
[FE-18] 월드컵 progress 바를 구현하라

### DIFF
--- a/src/components/worldCup/ResultWorldCupItem.test.tsx
+++ b/src/components/worldCup/ResultWorldCupItem.test.tsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react';
+
+import FIXTURE_FOOD_WORLD_CUP_ITEM from '@/fixtures/foodWorldCupItem';
+import InjectTestingRecoil from '@/test/InjectTestingRecoil';
+
+import ResultWorldCupItem from './ResultWorldCupItem';
+
+describe('ResultWorldCupItem', () => {
+  const renderResultWorldCupItem = () => render((
+    <InjectTestingRecoil worldCupItems={[{
+      ...FIXTURE_FOOD_WORLD_CUP_ITEM,
+      round: given.round,
+    }]}
+    >
+      <ResultWorldCupItem />
+    </InjectTestingRecoil>
+  ));
+
+  context('1등한 음식점이 존재하지 않는 경우', () => {
+    given('round', () => 16);
+
+    it('아무것도 나타나지 않아야만 한다', () => {
+      const { container } = renderResultWorldCupItem();
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  context('1등한 음식점이 존재하는 경우', () => {
+    given('round', () => 1);
+
+    it('1등한 음식점에 대한 정보가 나타나야만 한다', () => {
+      const { container } = renderResultWorldCupItem();
+
+      expect(container).toHaveTextContent(FIXTURE_FOOD_WORLD_CUP_ITEM.place_name);
+    });
+  });
+});

--- a/src/components/worldCup/ResultWorldCupItem.tsx
+++ b/src/components/worldCup/ResultWorldCupItem.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { useRecoilValue } from 'recoil';
+
+import { worldCupState } from '@/recoil/worldCup/atom';
+
+import WorldCupItem from './WorldCupItem';
+
+function ResultWorldCupItem() {
+  const worldCupItems = useRecoilValue(worldCupState);
+
+  const winnerItem = worldCupItems.find((item) => item.round === 1);
+
+  if (!winnerItem) {
+    return null;
+  }
+
+  return (
+    <WorldCupItem
+      worldCupItem={winnerItem}
+    />
+  );
+}
+
+export default ResultWorldCupItem;

--- a/src/components/worldCup/RoundProgressItem.test.tsx
+++ b/src/components/worldCup/RoundProgressItem.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+
+import lightTheme from '@/styles/theme';
+import MockTheme from '@/test/MockTheme';
+
+import RoundProgressItem from './RoundProgressItem';
+
+describe('RoundProgressItem', () => {
+  const renderRoundProgressItem = () => render((
+    <MockTheme>
+      <RoundProgressItem
+        roundLabel="16강"
+        isPastRound={given.isPastRound}
+        isFirstRound={given.isFirstRound}
+      />
+    </MockTheme>
+  ));
+
+  context('isPastRound가 true인 경우', () => {
+    given('isPastRound', () => true);
+
+    it(`색상이 ${lightTheme.main400}이여야만 한다`, () => {
+      renderRoundProgressItem();
+
+      expect(screen.getByTestId('round-label')).toHaveStyle({
+        color: lightTheme.main400,
+      });
+    });
+  });
+
+  context('isPastRound가 false인 경우', () => {
+    given('isPastRound', () => false);
+
+    it(`색상이 ${lightTheme.gray900}이여야만 한다`, () => {
+      renderRoundProgressItem();
+
+      expect(screen.getByTestId('round-label')).toHaveStyle({
+        color: lightTheme.gray900,
+      });
+    });
+  });
+
+  context('isFirstRound가 false인 경우', () => {
+    given('isFirstRound', () => false);
+
+    it('progress line이 나타나야만 한다', () => {
+      renderRoundProgressItem();
+
+      expect(screen.getByTestId('progress-line')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/worldCup/RoundProgressItem.tsx
+++ b/src/components/worldCup/RoundProgressItem.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+interface Props {
+  roundLabel: string;
+  isPastRound: boolean;
+  isFirstRound?: boolean;
+}
+
+function RoundProgressItem({ roundLabel, isPastRound, isFirstRound = false }: Props) {
+  return (
+    <RoundProgressItemWrapper>
+      <div>
+        {!isFirstRound && (
+          <ProgressLine isPastRound={isPastRound} data-testid="progress-line" />
+        )}
+        <ProgressDot isPastRound={isPastRound}>
+          <Dot />
+        </ProgressDot>
+      </div>
+      <RoundLabel isPastRound={isPastRound} data-testid="round-label">
+        {roundLabel}
+      </RoundLabel>
+    </RoundProgressItemWrapper>
+  );
+}
+
+export default RoundProgressItem;
+
+const RoundProgressItemWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 43px;
+
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 14px;
+  text-align: center;
+  letter-spacing: -0.005em;
+
+  & > div:first-of-type {
+    margin-bottom: 7px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+`;
+
+const ProgressDot = styled.div<{ isPastRound: boolean; }>`
+  position: relative;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  box-sizing: border-box;
+
+  ${({ theme, isPastRound }) => (isPastRound ? css`
+    background: rgba(235, 79, 39, 0.3);
+  ` : css`
+    border: 1px solid ${theme.gray900};
+  `)}
+
+  & > div {
+    display: ${({ isPastRound }) => (isPastRound ? 'block' : 'none')};
+    background-color:${({ theme }) => theme.main400};
+  }
+`;
+
+const Dot = styled.div`
+  border-radius: 50%;
+  width: 8px;
+  height: 8px;
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  z-index: 1;
+`;
+
+const ProgressLine = styled.div<{ isPastRound: boolean; }>`
+  width: 25px;
+  right: 30px;
+  position: absolute;
+  border: 1px dashed ${({ theme, isPastRound }) => (isPastRound ? theme.main400 : theme.gray900)};
+`;
+
+const RoundLabel = styled.div<{ isPastRound: boolean; }>`
+  color: ${({ theme, isPastRound }) => (isPastRound ? theme.main400 : theme.gray900)};
+`;

--- a/src/components/worldCup/RunWorldCup.tsx
+++ b/src/components/worldCup/RunWorldCup.tsx
@@ -103,7 +103,6 @@ function RunWorldCup({ currentRound, setCurrentRound }: RunWorldCupProps) {
         selectedItemId={selectedItemId}
         onClick={onSelectedItem}
       />
-
       {!!selectedItemId && (
         <Button type="button" onClick={onSelect}>
           선택
@@ -117,6 +116,7 @@ export default RunWorldCup;
 
 const RunWorldCupWrapper = styled.div`
   position: relative;
+  margin-top: 23px;
 
   & > div:first-of-type {
     margin-bottom: 15px;

--- a/src/components/worldCup/WorldCupItem.tsx
+++ b/src/components/worldCup/WorldCupItem.tsx
@@ -11,12 +11,12 @@ import ExternalLink from '../common/ExternalLink';
 
 interface Props {
   worldCupItem: FoodWorldCupItem;
-  onClick: (selectedId: string) => void;
+  onClick?: (selectedId: string) => void;
   selectedItemId?: string;
 }
 
 function WorldCupItem({ worldCupItem, onClick, selectedItemId }: Props) {
-  const handleClick = () => onClick(worldCupItem.id);
+  const handleClick = () => onClick?.(worldCupItem.id);
 
   const isSelected = selectedItemId === worldCupItem.id;
 

--- a/src/components/worldCup/WorldCupRoundProgress.test.tsx
+++ b/src/components/worldCup/WorldCupRoundProgress.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+
+import WorldCupRoundProgress from './WorldCupRoundProgress';
+
+describe('WorldCupRoundProgress', () => {
+  const renderWorldCupRoundProgress = () => render((
+    <WorldCupRoundProgress currentRound={16} />
+  ));
+
+  it('월드컵 진행 해더가 나타나야만 한다', () => {
+    const { container } = renderWorldCupRoundProgress();
+
+    expect(container).toHaveTextContent('16강');
+  });
+});

--- a/src/components/worldCup/WorldCupRoundProgress.tsx
+++ b/src/components/worldCup/WorldCupRoundProgress.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import styled from '@emotion/styled';
+
+import RoundProgressItem from './RoundProgressItem';
+
+interface Props {
+  currentRound: number;
+}
+
+function WorldCupRoundProgress({ currentRound }: Props) {
+  const isPastRound = (round: number) => round >= currentRound;
+
+  return (
+    <RoundProgressWrapper>
+      <RoundProgressItem
+        roundLabel="16강"
+        isPastRound={isPastRound(16)}
+        isFirstRound
+      />
+      <RoundProgressItem
+        roundLabel="8강"
+        isPastRound={isPastRound(8)}
+      />
+      <RoundProgressItem
+        roundLabel="4강"
+        isPastRound={isPastRound(4)}
+      />
+      <RoundProgressItem
+        roundLabel="FINAL"
+        isPastRound={isPastRound(2)}
+      />
+    </RoundProgressWrapper>
+  );
+}
+
+export default WorldCupRoundProgress;
+
+const RoundProgressWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 10px;
+  right: 0px;
+  left: 0px;
+  width: 100%;
+`;

--- a/src/hooks/api/useFetchFoodWorldCup.test.ts
+++ b/src/hooks/api/useFetchFoodWorldCup.test.ts
@@ -9,16 +9,24 @@ import useFetchFoodWorldCup from './useFetchFoodWorldCup';
 jest.mock('@/api/worldCup');
 
 describe('useFetchFoodWorldCup', () => {
+  const { env } = process;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetModules();
+    process.env = { ...env };
 
     (fetchFoodWorldCup as jest.Mock).mockResolvedValue([FIXTURE_FOOD_WORLD_CUP_ITEM]);
   });
 
+  afterEach(() => {
+    process.env = env;
+  });
+
   const requestForm = {
     food: ['한식'],
-    latitude: 37.5429123,
-    longitude: 127.0672672,
+    latitude: 1,
+    longitude: 1,
     radius: 1000,
     round: 16,
   };
@@ -28,15 +36,41 @@ describe('useFetchFoodWorldCup', () => {
     { wrapper },
   );
 
-  it('fetchFoodWorldCup api를 호출해야만 한다.', async () => {
-    const { result, waitFor } = useFetchFoodWorldCupHook();
-
-    await waitFor(() => result.current.isSuccess);
-
-    expect(fetchFoodWorldCup).toBeCalledWith({
-      ...requestForm,
-      food: requestForm.food.join('|'),
+  context('production 환경인 경우', () => {
+    beforeEach(() => {
+      (process.env.NODE_ENV as unknown as string) = 'production';
     });
-    expect(result.current.data).toEqual([FIXTURE_FOOD_WORLD_CUP_ITEM]);
+
+    it('fetchFoodWorldCup api를 호출해야만 한다.', async () => {
+      const { result, waitFor } = useFetchFoodWorldCupHook();
+
+      await waitFor(() => result.current.isSuccess);
+
+      expect(fetchFoodWorldCup).toBeCalledWith({
+        ...requestForm,
+        food: requestForm.food.join('|'),
+      });
+      expect(result.current.data).toEqual([FIXTURE_FOOD_WORLD_CUP_ITEM]);
+    });
+  });
+
+  context('production 환경이 아닌 경우', () => {
+    beforeEach(() => {
+      (process.env.NODE_ENV as unknown as string) = 'development';
+    });
+
+    it('fetchFoodWorldCup api를 호출해야만 한다.', async () => {
+      const { result, waitFor } = useFetchFoodWorldCupHook();
+
+      await waitFor(() => result.current.isSuccess);
+
+      expect(fetchFoodWorldCup).toBeCalledWith({
+        ...requestForm,
+        latitude: 37.5429123,
+        longitude: 127.0672672,
+        food: requestForm.food.join('|'),
+      });
+      expect(result.current.data).toEqual([FIXTURE_FOOD_WORLD_CUP_ITEM]);
+    });
   });
 });

--- a/src/hooks/api/useFetchFoodWorldCup.ts
+++ b/src/hooks/api/useFetchFoodWorldCup.ts
@@ -2,14 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 
 import { fetchFoodWorldCup } from '@/api/worldCup';
 import { FoodWorldCupForm } from '@/recoil/foodFilter/atom';
-import { checkEmpty, checkNumNull } from '@/utils/utils';
+import { checkEmpty, checkNumNull, isProd } from '@/utils/utils';
 
 function useFetchFoodWorldCup(form: FoodWorldCupForm, enabled: boolean) {
   const requestForm = {
     ...form,
-    // TODO - 삭제 테스트용
-    latitude: 37.5429123,
-    longitude: 127.0672672,
+    latitude: isProd(process.env.NODE_ENV) ? form.latitude : 37.5429123,
+    longitude: isProd(process.env.NODE_ENV) ? form.longitude : 127.0672672,
     food: form.food.join('|'),
     round: checkNumNull(form.round),
   };

--- a/src/pages/world-cup/index.page.tsx
+++ b/src/pages/world-cup/index.page.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 
-import styled from '@emotion/styled';
 import { useRecoilValue } from 'recoil';
 
 import RunWorldCup from '@/components/worldCup/RunWorldCup';
+import WorldCupRoundProgress from '@/components/worldCup/WorldCupRoundProgress';
 import { foodWorldCupFormState } from '@/recoil/foodFilter/atom';
 import { checkNumNull } from '@/utils/utils';
 
@@ -13,20 +13,9 @@ function WorldCupPage() {
 
   return (
     <>
-      <WorldCupHeader>
-        <div>
-          16강
-        </div>
-        <div>
-          8강
-        </div>
-        <div>
-          4강
-        </div>
-        <div>
-          FINAL
-        </div>
-      </WorldCupHeader>
+      <WorldCupRoundProgress
+        currentRound={currentRound}
+      />
       <RunWorldCup
         currentRound={currentRound}
         setCurrentRound={setCurrentRound}
@@ -36,7 +25,3 @@ function WorldCupPage() {
 }
 
 export default WorldCupPage;
-
-const WorldCupHeader = styled.div`
-  color: ${({ theme }) => theme.white};
-`;

--- a/src/pages/world-cup/result.page.tsx
+++ b/src/pages/world-cup/result.page.tsx
@@ -1,13 +1,31 @@
 import React from 'react';
 
+import styled from '@emotion/styled';
+
+import ResultWorldCupItem from '@/components/worldCup/ResultWorldCupItem';
+
 function WorldCupResultPage() {
   return (
     <div>
-      오늘 2차장소는
-      <br />
-      바로 여기 🔔
+      <WorldCupResultPageTitle>
+        오늘 2차장소는
+        <br />
+        바로 여기 🔔
+      </WorldCupResultPageTitle>
+      <ResultTip>
+        어디갈지 정했으니 얼른 자리를 옮겨볼까요? 🤘🏻
+      </ResultTip>
+      <ResultWorldCupItem />
     </div>
   );
 }
 
 export default WorldCupResultPage;
+
+const WorldCupResultPageTitle = styled.div`
+  color: ${({ theme }) => theme.white};
+`;
+
+const ResultTip = styled.div`
+  color: ${({ theme }) => theme.gray200};
+`;

--- a/src/pages/world-cup/result.test.tsx
+++ b/src/pages/world-cup/result.test.tsx
@@ -1,10 +1,14 @@
 import { render } from '@testing-library/react';
 
+import InjectTestingRecoil from '@/test/InjectTestingRecoil';
+
 import ResultPage from './result.page';
 
 describe('ResultPage', () => {
   const renderResultPage = () => render((
-    <ResultPage />
+    <InjectTestingRecoil>
+      <ResultPage />
+    </InjectTestingRecoil>
   ));
 
   it('"오늘 2차장소는" 문구가 나타나야만 한다', () => {

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,6 +1,10 @@
 import {
   checkEmpty,
-  checkNull, checkNumNull, convertToNumber, emptyAThenB,
+  checkNull,
+  checkNumNull,
+  convertToNumber,
+  emptyAThenB,
+  isProd,
 } from './utils';
 
 describe('checkNull', () => {
@@ -103,6 +107,24 @@ describe('checkEmpty', () => {
       const result = checkEmpty(mockArray);
 
       expect(result).toEqual(mockArray);
+    });
+  });
+});
+
+describe('isProd', () => {
+  context('production 환경일 경우', () => {
+    it('true를 반환해야만 한다', () => {
+      const result = isProd('production');
+
+      expect(result).toBeTruthy();
+    });
+  });
+
+  context('production 환경이 아닌 경우', () => {
+    it('false를 반환해야만 한다', () => {
+      const result = isProd('development');
+
+      expect(result).toBeFalsy();
     });
   });
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -37,3 +37,5 @@ export const checkEmpty = <T>(value?: T[]): T[] => {
 
   return value;
 };
+
+export const isProd = (env: string): boolean => env === 'production';


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- 월드컵 진행사황을 볼 수 있는 progress bar를 구현

## 🎉 어떻게 해결했나요?
- 월드컵 진행사황을 볼 수 있는 progress bar를 구현
- isProd util함수 구현

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

### 🔗 Jira link
<!-- - https://dnd-7th-3.atlassian.net/browse/<티켓번호> -->
- https://dnd-7th-3.atlassian.net/browse/FE-18
 